### PR TITLE
add 'testing' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ repository = "https://github.com/cmr/netlib-src"
 build = "build.rs"
 links = "blas"
 exclude = [
-    "source/TESTING/*",
     "source/BLAS/TESTING/*",
     "source/CBLAS/testing/*",
 ]
 
 [features]
-default = ["cblas", "lapacke"]
+default = ["cblas", "lapacke", "testing"]
 
 cblas = []
 lapacke = []
 static = []
+testing = []
 system = []
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,18 @@ repository = "https://github.com/cmr/netlib-src"
 build = "build.rs"
 links = "blas"
 exclude = [
+    "source/TESTING/*.in",
     "source/BLAS/TESTING/*",
     "source/CBLAS/testing/*",
 ]
 
 [features]
-default = ["cblas", "lapacke", "testing"]
+default = ["cblas", "lapacke", "tmg"]
 
 cblas = []
 lapacke = []
 static = []
-testing = []
+tmg = []
 system = []
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The following Cargo features are supported:
 
 * `cblas` to build CBLAS (enabled by default),
 * `lapacke` to build LAPACKE (enabled by default),
-* `testing` to build TESTING/MATGEN routines (enabled by default),
+* `tmg` to build TESTING/MATGEN routines (enabled by default),
 * `static` to link to Netlib statically, and
 * `system` to skip building the bundled Netlib.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The following Cargo features are supported:
 
 * `cblas` to build CBLAS (enabled by default),
 * `lapacke` to build LAPACKE (enabled by default),
+* `testing` to build TESTING/MATGEN routines (enabled by default),
 * `static` to link to Netlib statically, and
 * `system` to skip building the bundled Netlib.
 

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() {
     let kind = if feature!("STATIC") { "static" } else { "dylib" };
     let cblas = feature!("CBLAS");
     let lapacke = feature!("LAPACKE");
+    let testing = feature!("TESTING");
 
     if !feature!("SYSTEM") {
         let source = PathBuf::from("source");
@@ -25,7 +26,7 @@ fn main() {
         }
 
         let output = Config::new(&source)
-                            .define("BUILD_TESTING", "OFF")
+                            .define("BUILD_TESTING", switch!(testing))
                             .define("BUILD_SHARED_LIBS", switch!(kind == "dylib"))
                             .define("CBLAS", switch!(cblas))
                             .define("LAPACKE", switch!(lapacke))
@@ -43,5 +44,8 @@ fn main() {
     }
     if lapacke {
         println!("cargo:rustc-link-lib={}=lapacke", kind);
+    }
+    if testing {
+        println!("cargo:rustc-link-lib={}=tmglib", kind);
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
     let kind = if feature!("STATIC") { "static" } else { "dylib" };
     let cblas = feature!("CBLAS");
     let lapacke = feature!("LAPACKE");
-    let testing = feature!("TESTING");
+    let tmg = feature!("TMG");
 
     if !feature!("SYSTEM") {
         let source = PathBuf::from("source");
@@ -26,7 +26,8 @@ fn main() {
         }
 
         let output = Config::new(&source)
-                            .define("BUILD_TESTING", switch!(testing))
+                            .define("BUILD_TESTING", "OFF")
+                            .define("LAPACKE_WITH_TMG", switch!(tmg))
                             .define("BUILD_SHARED_LIBS", switch!(kind == "dylib"))
                             .define("CBLAS", switch!(cblas))
                             .define("LAPACKE", switch!(lapacke))
@@ -45,7 +46,7 @@ fn main() {
     if lapacke {
         println!("cargo:rustc-link-lib={}=lapacke", kind);
     }
-    if testing {
+    if tmg {
         println!("cargo:rustc-link-lib={}=tmglib", kind);
     }
 }


### PR DESCRIPTION
This adds a 'testing' feature, which compiles and links the tmglib library containing all of the matrix generation routines in TESTING/MATGEN.

I thought it appropriate to make 'testing' a default feature, since openblas-src builds these test routines by default.